### PR TITLE
General improvements

### DIFF
--- a/configuration.example.php
+++ b/configuration.example.php
@@ -7,14 +7,14 @@
 // Base URL
 $base_path = 'http://localhost:8888';
 
-// Database variables used for temporarily verifying the information regarding
-// the emergency note that needs to be processed
+// Database variables used for temporarily verifying the information regarding the emergency note that needs to be processed
 $db_host = 'localhost';
 $db_user = 'root';
 $db_password = 'root';
 $db_db = 'we_expire';
 
 // SMTP variables used for sending email notifications
+// Make sure the SMTP configuration is compliant with PHPMailer documentation (https://github.com/PHPMailer/PHPMailer)
 $SMTP_host        = '';
 $SMTP_username    = '';
 $SMTP_password    = '';

--- a/htdocs/PHP/internal_libraries/languages/mail_content_en.php
+++ b/htdocs/PHP/internal_libraries/languages/mail_content_en.php
@@ -13,8 +13,9 @@ $translation["access_request_html_content"] = "<p>Hi,</p>
                   <p>Someone is trying to access your emergency note that has the following subject: <b>{$subject}</b></p>
                   <p>If you want to temporarily block the access of this note for 60 days, you must hit the link below:</p>
                   <p><b><a href='{$base_path}/block.php?m={$hashed_note}' target='_blank'>Yes, I want to temporarily block the access of this note for 60 days</a></b></p>
+                  <p>After these 60 days, you will receive a new notification if someone tries to access your emergency note again.</p>
                   <hr>
                   <p>Have questions or need help? Just write us at <a href='mailto:{$SMTP_username}'>{$SMTP_username}</a></p>";
-$translation["access_request_non-html_content"] = "Hi, someone is trying to access your emergency note that has the following subject: {$subject}. If you want to temporarily block the access of this note for 60 days, you must visit the following URL on your browser: {$base_path}/block.php?m={$hashed_note}. Have questions or need help? Just write us at {$SMTP_username}";
+$translation["access_request_non-html_content"] = "Hi, someone is trying to access your emergency note that has the following subject: {$subject}. If you want to temporarily block the access of this note for 60 days, you must visit the following URL on your browser: {$base_path}/block.php?m={$hashed_note}. After these 60 days, you will receive a new notification if someone tries to access your emergency note again. Have questions or need help? Just write us at {$SMTP_username}";
 
 ?>

--- a/htdocs/PHP/internal_libraries/languages/mail_content_es.php
+++ b/htdocs/PHP/internal_libraries/languages/mail_content_es.php
@@ -13,8 +13,9 @@ $translation["access_request_html_content"] = "<p>Hola,</p>
                   <p>Alguien está intentando acceder a tu mensaje de emergencia que tiene el siguiente título: <b>{$subject}</b></p>
                   <p>Si quieres bloquear temporalmente durante 60 días el acceso al mensaje pulsa en el siguiente enlace:</p>
                   <p><b><a href='{$base_path}/block.php?m={$hashed_note}' target='_blank'>Si, quiero bloquear temporalmente durante 60 días el acceso al mensaje</a></b></p>
+                  <p>Después de estos 60 días, recibirás una nueva notificación si alguien intenta acceder nuevamente a tu nota de emergencia.</p>
                   <hr>
                   <p>¿Tienes dudas o necesitas ayuda? Escríbenos a <a href='mailto:{$SMTP_username}'>{$SMTP_username}</a></p>";
-$translation["access_request_non-html_content"] = "Hola, alguien está intentando acceder a tu mensaje de emergencia que tiene el siguiente título: {$subject}. Si quieres bloquear temporalmente durante 60 días el acceso al mensaje entra en el siguiente enlace URL de tu navegador: {$base_path}/block.php?m={$hashed_note}. ¿Tienes dudas o necesitas ayuda? Escríbenos a {$SMTP_username}";
+$translation["access_request_non-html_content"] = "Hola, alguien está intentando acceder a tu mensaje de emergencia que tiene el siguiente título: {$subject}. Si quieres bloquear temporalmente durante 60 días el acceso al mensaje entra en el siguiente enlace URL de tu navegador: {$base_path}/block.php?m={$hashed_note}. Después de estos 60 días, recibirás una nueva notificación si alguien intenta acceder nuevamente a tu nota de emergencia. ¿Tienes dudas o necesitas ayuda? Escríbenos a {$SMTP_username}";
 
 ?>

--- a/htdocs/PHP/internal_libraries/languages/mail_content_fr.php
+++ b/htdocs/PHP/internal_libraries/languages/mail_content_fr.php
@@ -13,8 +13,9 @@ $translation["access_request_html_content"] = "<p>Bonjour,</p>
                   <p>Quelqu'un essaie d'accéder à votre note d'urgence dont l'objet est le suivant : <b>{$subject}</b></p>
                   <p>Si vous voulez bloquer temporairement l'accès à cette note pendant 60 jours, vous devez cliquer sur le lien ci-dessous:</p>
                   <p><b><a href='{$base_path}/block.php?m={$hashed_note}' target='_blank'>Oui, je veux bloquer temporairement l'accès à cette note pendant 60 jours.</a></b></p>
+                  <p>Après ces 60 jours, vous recevrez une nouvelle notification si quelqu'un tente à nouveau d'accéder à votre note d'urgence.</p>
                   <hr>
                   <p>Vous avez des questions ou besoin d'aide ? Écrivez-nous à <a href='mailto:{$SMTP_username}'>{$SMTP_username}</a></p>";
-$translation["access_request_non-html_content"] = "Bonjour, quelqu'un essaie d'accéder à votre note d'urgence qui a le sujet suivant : {$subject}. Si vous souhaitez bloquer temporairement l'accès à cette note pendant 60 jours, vous devez visiter l'URL suivante sur votre navigateur : {$base_path}/block.php?m={$hashed_note}. Vous avez des questions ou besoin d'aide ? Écrivez-nous à {$SMTP_username}";
+$translation["access_request_non-html_content"] = "Bonjour, quelqu'un essaie d'accéder à votre note d'urgence qui a le sujet suivant : {$subject}. Si vous souhaitez bloquer temporairement l'accès à cette note pendant 60 jours, vous devez visiter l'URL suivante sur votre navigateur : {$base_path}/block.php?m={$hashed_note}. Après ces 60 jours, vous recevrez une nouvelle notification si quelqu'un tente à nouveau d'accéder à votre note d'urgence. Vous avez des questions ou besoin d'aide ? Écrivez-nous à {$SMTP_username}";
 
 ?>

--- a/htdocs/PHP/internal_libraries/languages/mail_content_it.php
+++ b/htdocs/PHP/internal_libraries/languages/mail_content_it.php
@@ -13,8 +13,9 @@ $translation["access_request_html_content"] = "<p>Ciao,</p>
                   <p>Qualcuno sta provando ad accedere ad una tua nota d'emergenza che ha il seguente oggetto: <b>{$subject}</b></p>
                   <p>Se vuoi bloccare temporaneamente l'accesso alla nota per 60 giorni devi premere il link sottostante:</p>
                   <p><b><a href='{$base_path}/block.php?m={$hashed_note}' target='_blank'>Si, voglio temporaneamente bloccare l'accesso alla nota per 60 giorni</a></b></p>
+                  <p>Trascorsi questi 60 giorni riceverai una nuova notifica qualora qualcuno tenterà di accedere nuovamente alla tua nota d'emergenza.</p>
                   <hr>
                   <p>Hai domande o hai bisogno di aiuto? Scrivici a <a href='mailto:{$SMTP_username}'>{$SMTP_username}</a></p>";
-$translation["access_request_non-html_content"] = "Ciao, qualcuno sta provando ad accedere alla tua nota d'emergenza che ha il seguente oggetto: {$subject}. Se vuoi bloccare temporaneamente l'accesso alla nota per 60 giorni devi visitare il seguente URL nel tuo browser: {$base_path}/block.php?m={$hashed_note}. Hai domande o hai bisogno di aiuto? Scrivici a {$SMTP_username}";
+$translation["access_request_non-html_content"] = "Ciao, qualcuno sta provando ad accedere alla tua nota d'emergenza che ha il seguente oggetto: {$subject}. Se vuoi bloccare temporaneamente l'accesso alla nota per 60 giorni devi visitare il seguente URL nel tuo browser: {$base_path}/block.php?m={$hashed_note}. Trascorsi questi 60 giorni riceverai una nuova notifica qualora qualcuno tenterà di accedere nuovamente alla tua nota d'emergenza. Hai domande o hai bisogno di aiuto? Scrivici a {$SMTP_username}";
 
 ?>

--- a/htdocs/PHP/internal_libraries/languages/page_content_en.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_en.php
@@ -101,8 +101,8 @@ $translation["access_page_access_code_input_title"] = "Please enter the access c
 $translation["access_page_access_code_input_error"] = "The access code you provided or the note you are trying to access is invalid.";
 
 // Note page
-// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time or grant access variables exist
-if (isset($creation_date_time) or isset($_SESSION['grant_access'])) {
+// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time and the grant access variables exist
+if (isset($creation_date_time) and isset($_SESSION['grant_access'])) {
 $translation["note_page_title"] = "Read the note";
 $translation["note_page_waiting_message"] = "<p class='text-center'>The access code for this note has been successfully verified. However, it is necessary to wait until <b>".date("d/m/Y", strtotime($_SESSION['grant_access']))."</b> (DD/MM/YYYY) in order to read the content of the note.</p>
 <p class='text-center'>This waiting time depends on the inactivity time chosen by the creator of this note. We therefore invite you to try to access the emergency note again on the date indicated above, which is when the inactivity time will be over.</p>";

--- a/htdocs/PHP/internal_libraries/languages/page_content_es.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_es.php
@@ -101,8 +101,8 @@ $translation["access_page_access_code_input_title"] = "Introduce el código de a
 $translation["access_page_access_code_input_error"] = "El código de acceso que has introducido o el mensaje al que estás intentando acceder no son válidos.";
 
 // Note page
-// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time or grant access variables exist
-if (isset($creation_date_time) or isset($_SESSION['grant_access'])) {
+// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time and the grant access variables exist
+if (isset($creation_date_time) and isset($_SESSION['grant_access'])) {
 $translation["note_page_title"] = "Lee el mensaje";
 $translation["note_page_waiting_message"] = "<p class='text-center'>El código de acceso de este mensaje ha sido verificado correctamente. Para leer el contenido del mismo debes esperar hasta el <b>".date("d/m/Y", strtotime($_SESSION['grant_access']))."</b> (DD/MM/AAAA).</p>
 <p class='text-center'>Este tiempo de espera depende del tiempo de inactividad elegido por quien ha creado el mensaje. Te invitamos a acceder de nuevo a partir de la fecha indicada, cuando haya vencido el tiempo de inactividad.</p>";

--- a/htdocs/PHP/internal_libraries/languages/page_content_fr.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_fr.php
@@ -103,8 +103,8 @@ $translation["access_page_access_code_input_title"] = "Veuillez entrer le code d
 $translation["access_page_access_code_input_error"] = "Le code d'accès que vous avez fourni ou la note à laquelle vous essayez d'accéder n'est pas valide.";
 
 // Note page
-// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time or grant access variables exist
-if (isset($creation_date_time) or isset($_SESSION['grant_access'])) {
+// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time and the grant access variables exist
+if (isset($creation_date_time) and isset($_SESSION['grant_access'])) {
 $translation["note_page_title"] = "Lire la note";
 $translation["note_page_waiting_message"] = "<p class='text-center'>Le code d'accès à cette note a été vérifié avec succès. Cependant, il est nécessaire d'attendre jusqu'au <b>".date("d/m/Y", strtotime($_SESSION['grant_access']))."</b> (DD/MM/YYYY) afin de lire le contenu de la note.</p>
 <p class='text-center'>Ce temps d'attente dépend de la durée d'inactivité choisie par le créateur de cette note. Nous vous invitons donc à réessayer d'accéder à la note d'urgence à la date indiquée ci-dessus, date à laquelle le temps d'inactivité sera passé.</p>";

--- a/htdocs/PHP/internal_libraries/languages/page_content_it.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_it.php
@@ -101,8 +101,8 @@ $translation["access_page_access_code_input_title"] = "Inserisci il codice di ac
 $translation["access_page_access_code_input_error"] = "Il codice di accesso che hai inserito o la nota a cui stai provando ad accedere non sono validi.";
 
 // Note page
-// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time or grant access variables exist
-if (isset($creation_date_time) or isset($_SESSION['grant_access'])) {
+// Avoid warning errors when visiting a page different than the note page by just checking first if the creation date time and the grant access variables exist
+if (isset($creation_date_time) and isset($_SESSION['grant_access'])) {
 $translation["note_page_title"] = "Leggi la nota";
 $translation["note_page_waiting_message"] = "<p class='text-center'>Il codice d'accesso per questa nota è stato verificato correttamente. Tuttavia per leggerne il contenuto è necessario attendere il <b>".date("d/m/Y", strtotime($_SESSION['grant_access']))."</b> (GG/MM/AAAA).</p>
 <p class='text-center'>Questo tempo di attesa dipende dal tempo di inattività scelto da chi ha creato questa nota. Ti invitiamo dunque a riprovare ad accedere nuovamente nella data indicata, ovvero quando il tempo di inattività sarà stato superato.</p>";

--- a/htdocs/PHP/internal_libraries/page_templates/footer.php
+++ b/htdocs/PHP/internal_libraries/page_templates/footer.php
@@ -31,10 +31,10 @@ global $base_path;
           ?>
         </button>
         <ul class="dropdown-menu" aria-label="<?=$translation["footer_language"];?>">
-          <li><a class="dropdown-item" href="<?=$base_path;?>/en">English</a></li>
-          <li><a class="dropdown-item" href="<?=$base_path;?>/es">Español</a></li>
-          <li><a class="dropdown-item" href="<?=$base_path;?>/fr">Français</a></li>
-          <li><a class="dropdown-item" href="<?=$base_path;?>/it">Italiano</a></li>
+          <li><a class="dropdown-item" href="<?=$base_path;?>/?l=en">English</a></li>
+          <li><a class="dropdown-item" href="<?=$base_path;?>/?l=es">Español</a></li>
+          <li><a class="dropdown-item" href="<?=$base_path;?>/?l=fr">Français</a></li>
+          <li><a class="dropdown-item" href="<?=$base_path;?>/?l=it">Italiano</a></li>
         </ul>
       </div>
     </div>

--- a/htdocs/PHP/internal_libraries/page_templates/head.php
+++ b/htdocs/PHP/internal_libraries/page_templates/head.php
@@ -7,7 +7,6 @@
 <link rel="alternate" hreflang="fr" href="https://weexpire.org/fr">
 <link rel="alternate" hreflang="it" href="https://weexpire.org/it">
 
-
 <title><?=$translation["title"];?></title>
 <meta name="description" content="<?=$translation["meta_description"];?>">
 <meta name="author" content="WeExpire">
@@ -32,9 +31,9 @@
 <meta name="twitter:image" content="https://www.weexpire.org/img/social.jpg">
 <meta name="twitter:image:alt" content="WeExpire">
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
 <link href="/css/main.css" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous" async></script>
+<script async src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 <link rel="apple-touch-icon" sizes="180x180" href="/img/icons/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/img/icons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/img/icons/favicon-16x16.png">
@@ -43,4 +42,8 @@
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="theme-color" content="#ffffff">
 
+<?php 
+// Include Plausible Analytics only if server name is weexpire.org
+if ($_SERVER['SERVER_NAME'] = 'weexpire.org') { ?>
 <script defer data-domain="weexpire.org" src="https://plausible.io/js/plausible.js"></script>
+<?php } ?>

--- a/htdocs/done.php
+++ b/htdocs/done.php
@@ -12,8 +12,11 @@ include_once 'PHP/internal_libraries/engine/starter.php';
 require_once '../underwear/environment_variables/configuration.php';
 global $base_path, $current_note_version, $test_mode;
 
-// Check if there is a POST request and if the user is coming from the review.php page
-if (($_SERVER["REQUEST_METHOD"] == "POST") and ($_SESSION["page_token"] == "review_page")) {
+// Check if there is a POST request and if there is a page token set
+if (($_SERVER["REQUEST_METHOD"] == "POST") and isset($_SESSION["page_token"])) {
+
+  // Verify if the user is coming from the review page
+  if ($_SESSION["page_token"] == "review_page") {
 
   // Encrypt the emergency note
   require 'PHP/internal_libraries/engine/note_encryption.php';
@@ -26,9 +29,20 @@ if (($_SERVER["REQUEST_METHOD"] == "POST") and ($_SESSION["page_token"] == "revi
   // Set the page token
   $_SESSION["page_token"] = "done_page";
 
+  }
+
+  // If the user is not coming from the review.php page,
+  // then remove all the session variables, destroy the session and redirect to the index.php page
+  else {
+    session_unset();
+    session_destroy();
+    header("Location: /index.php");
+    exit();
+  }
+
 }
 
-// If there is no POST request and the user is not coming from the review.php page,
+// If there is no POST request and no page token set,
 // then remove all the session variables, destroy the session and redirect to the index.php page
 else {
   session_unset();

--- a/htdocs/pdf.php
+++ b/htdocs/pdf.php
@@ -64,6 +64,12 @@ and ($_SESSION["page_token"] == "done_page")) {
   $pdf->SetHeaderMargin(PDF_MARGIN_HEADER);
   $pdf->SetFooterMargin(PDF_MARGIN_FOOTER);
 
+  // set auto page breaks
+  $pdf->SetAutoPageBreak(TRUE, PDF_MARGIN_BOTTOM);
+
+  // Set display mode
+  $pdf->SetDisplayMode('fullpage', 'SinglePage', 'UseNone');
+  
   // Set auto page breaks
   $pdf->SetAutoPageBreak(TRUE, PDF_MARGIN_BOTTOM);
 
@@ -74,7 +80,7 @@ and ($_SESSION["page_token"] == "done_page")) {
   $pdf->SetFont('helvetica', '', 11);
 
   // Add a page
-  $pdf->AddPage('L');
+  $pdf->AddPage('L','A4');
 
   // Print HTML content
   if ($_SESSION["expiration_date"] == "None") {
@@ -101,6 +107,8 @@ and ($_SESSION["page_token"] == "done_page")) {
   // QRCODE,H : QR-CODE Best error correction
   // Include in the QR code the encrypted URL that allows the user to access the relative emergency note
   $pdf->write2DBarcode("{$base_path}/access.php?m={$_SESSION['encrypted_note']}&v={$current_note_version}", 'QRCODE', 180, 33, 100, 100, $style, 'N');
+
+  $pdf->lastPage();
 
   // Close and output the PDF document
   $pdf->Output('WeExpire_document.pdf', 'I');

--- a/htdocs/review.php
+++ b/htdocs/review.php
@@ -8,10 +8,11 @@
 include_once 'PHP/internal_libraries/engine/starter.php';
 
 // Check if there is a POST request first
-if ($_SERVER["REQUEST_METHOD"] == "POST") {
+if ($_SERVER["REQUEST_METHOD"] == "POST" and isset($_SESSION['csrf_token'])) {
 
   // Verify the secure form token in order to avoid any cross-domain POST request
-  // If it's not verified, redirect to the index.php page
+  // If it's not verified, then remove all the session variables, destroy the session 
+  // and redirect to the index.php page
   if($_SESSION['csrf_token'] !== $_POST['csrf_token']){
     session_unset();
     session_destroy();
@@ -19,82 +20,83 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     exit();
   }
 
-  // Set the page token, it will be used in the next page as a verifier
-  $_SESSION["page_token"] = "review_page";
-
-  // Set the variables according to the input values (without HTML or PHP tags)
-  $subject = strip_tags($_POST["subject"]);
-  $note = strip_tags($_POST["note"]);
-  $primary_email = strip_tags($_POST["primary_email"]);
-  $secondary_email = strip_tags($_POST["secondary_email"]);
-  $inactivity_time = strip_tags($_POST["inactivity_time"]);
-  $minimum_expiration_date = date('Y-m-d', strtotime(" + {$inactivity_time} days"));
-
-  // If the expiration date hasn't been passed via POST, then set it to "None"
-  if (!isset($_POST["expiration_date"])) {
-    $expiration_date = "None";
-  }
-
-  // If the expiration has been passed via POST and is higher or equal to the minimum expiration date,
-  // then set its relative value
-  elseif ($_POST["expiration_date"] >= $minimum_expiration_date) {
-    $expiration_date = date("Y-m-d", strtotime($_POST["expiration_date"]));
-  };
-
-  // For security reasons, truncate the value of the variables in case they are longer than supposed
-  $subject = substr($subject, 0, 100);
-  $note = substr($note, 0, 1000);
-  $primary_email = substr($primary_email, 0, 254);
-  $secondary_email = substr($secondary_email, 0, 254);
-
-  // Remove all the invalid characters from the email addresses
-  $primary_email = filter_var($primary_email, FILTER_SANITIZE_EMAIL);
-  $secondary_email = filter_var($secondary_email, FILTER_SANITIZE_EMAIL);
-
-  // Unset all the session variables, destroy the session and redirect to the start.php page
-  // in case the primary and secondary email addresses are the same
-  if ($primary_email == $secondary_email) {
-    session_unset();
-    session_destroy();
-    header("Location: /start.php");
-    exit();
-  }
-
-  // Unset all the session variables, destroy the session and redirect to the start.php page
-  // in case one of the mandatory variables is empty
-  if (empty($subject) or empty($note) or empty($primary_email) or empty($expiration_date)) {
-    session_unset();
-    session_destroy();
-    header("Location: /start.php");
-    exit();
-  }
-
-  // Unset all the session variables, destroy the session and redirect to the start.php page
-  // in case the inactivity time varialble doesn't match the presets values
-  if (!($inactivity_time >= 1 && $inactivity_time <= 180)) {
-    session_unset();
-    session_destroy();
-    header("Location: /start.php");
-    exit();
-  }
-
-  // Set the session variables that will be used in the next step (done.php page)
   else {
-    $_SESSION["subject"] = $subject;
-    $_SESSION["note"] = $note;
-    $_SESSION["primary_email"] = $primary_email;
-    $_SESSION["inactivity_time"] = $inactivity_time;
-    $_SESSION["expiration_date"] = $expiration_date;
+    // Set the page token, it will be used in the next page as a verifier
+    $_SESSION["page_token"] = "review_page";
 
-    // Set the secondary email value to "None" in case the input field was empty
-    if (empty($secondary_email)) {
-      $_SESSION["secondary_email"] = "None";
+    // Set the variables according to the input values (without HTML or PHP tags)
+    $subject = strip_tags($_POST["subject"]);
+    $note = strip_tags($_POST["note"]);
+    $primary_email = strip_tags($_POST["primary_email"]);
+    $secondary_email = strip_tags($_POST["secondary_email"]);
+    $inactivity_time = strip_tags($_POST["inactivity_time"]);
+    $minimum_expiration_date = date('Y-m-d', strtotime(" + {$inactivity_time} days"));
+
+    // If the expiration date hasn't been passed via POST, then set it to "None"
+    if (!isset($_POST["expiration_date"])) {
+      $expiration_date = "None";
     }
+
+    // If the expiration has been passed via POST and is higher or equal to the minimum expiration date,
+    // then set its relative value
+    elseif ($_POST["expiration_date"] >= $minimum_expiration_date) {
+      $expiration_date = date("Y-m-d", strtotime($_POST["expiration_date"]));
+    };
+
+    // For security reasons, truncate the value of the variables in case they are longer than supposed
+    $subject = substr($subject, 0, 100);
+    $note = substr($note, 0, 1000);
+    $primary_email = substr($primary_email, 0, 254);
+    $secondary_email = substr($secondary_email, 0, 254);
+
+    // Remove all the invalid characters from the email addresses
+    $primary_email = filter_var($primary_email, FILTER_SANITIZE_EMAIL);
+    $secondary_email = filter_var($secondary_email, FILTER_SANITIZE_EMAIL);
+
+    // Unset all the session variables, destroy the session and redirect to the start.php page
+    // in case the primary and secondary email addresses are the same
+    if ($primary_email == $secondary_email) {
+      session_unset();
+      session_destroy();
+      header("Location: /start.php");
+      exit();
+    }
+
+    // Unset all the session variables, destroy the session and redirect to the start.php page
+    // in case one of the mandatory variables is empty
+    if (empty($subject) or empty($note) or empty($primary_email) or empty($expiration_date)) {
+      session_unset();
+      session_destroy();
+      header("Location: /start.php");
+      exit();
+    }
+
+    // Unset all the session variables, destroy the session and redirect to the start.php page
+    // in case the inactivity time varialble doesn't match the presets values
+    if (!($inactivity_time >= 1 && $inactivity_time <= 180)) {
+      session_unset();
+      session_destroy();
+      header("Location: /start.php");
+      exit();
+    }
+
+    // Set the session variables that will be used in the next step (done.php page)
     else {
-      $_SESSION["secondary_email"] = $secondary_email;
+      $_SESSION["subject"] = $subject;
+      $_SESSION["note"] = $note;
+      $_SESSION["primary_email"] = $primary_email;
+      $_SESSION["inactivity_time"] = $inactivity_time;
+      $_SESSION["expiration_date"] = $expiration_date;
+
+      // Set the secondary email value to "None" in case the input field was empty
+      if (empty($secondary_email)) {
+        $_SESSION["secondary_email"] = "None";
+      }
+      else {
+        $_SESSION["secondary_email"] = $secondary_email;
+      }
     }
   }
-
 }
 
 // If there is no POST request then remove all the session variables,

--- a/htdocs/robots.txt
+++ b/htdocs/robots.txt
@@ -4,6 +4,7 @@ Disallow: /start
 Disallow: /terms
 Disallow: /privacy
 Disallow: /donate
+Disallow: /*?*
 
 Sitemap: https://weexpire.org/sitemap.xml
 


### PR DESCRIPTION
- Updated Bootstrap framework to 5.3.0 stable version
- Provided more information in the example configuration file about the SMTP settings
- Fixed small issues and conditional statements that were generating PHP warnings in logs
- Added condition in order to include Plausible Analytics only if the server name is weexpire.org
- Fixed URL language variables for the language button switch (footer) that were causing wrong redirects due to missing .htaccess configuration in local environments
- Disallowed query strings in robots.txt
- Added more information in the email notification about what happens to the emergency note once the 60 days blocking time is over