### PR TITLE
QR code reliability improvements

### DIFF
--- a/htdocs/PHP/internal_libraries/languages/page_content_en.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_en.php
@@ -97,7 +97,7 @@ $translation["review_page_information_6"] = "This note can’t be edited in the 
 $translation["done_page_title"] = "All done";
 $translation["done_page_content"] = "
 <p>Your emergency note has been created. You can download it by clicking the button below, then print it and deliver it to your trusted person.</p>
-<p><b><mark>Very important!</mark></b> Add the email address <b>support@weexpire.org</b> to your email provider’s safe senders list to prevent any notification from us regarding the note you just created from mistakenly ending up in spam.</p>";
+<p><b><mark>Very important!</mark></b> Add the email address <b>support@weexpire.org</b> to your email provider’s safe senders list to prevent any notification from us regarding the note you just created from mistakenly ending up in spam.<br>Also, make sure the QR code and its access code are printed in full and clearly legible. If needed, adjust the print scale and margins. Finally, scan the QR code with your phone’s camera only to make sure it opens the access page for your emergency note, without going any further.</p>";
 $translation["done_page_donate_message"] = "<p class='text-center'><small>Support WeExpire with a <a href='/donate' target='_blank'>donation</a>.</small></p>";
 
 // Access page

--- a/htdocs/PHP/internal_libraries/languages/page_content_es.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_es.php
@@ -98,7 +98,7 @@ $translation["review_page_information_6"] = "Este mensaje no podrá cambiarse en
 $translation["done_page_title"] = "Ya está!";
 $translation["done_page_content"] = "
 <p>Tu mensaje de emergencia se ha creado. Puedes descargarlo en el botón de abajo e imprimirlo para entregárselo a tu contacto de confianza.</p>
-<p><b><mark>¡Muy importante!</mark></b> Incluye la dirección <b>support@weexpire.org</b> en tu lista de contacto seguros para evitar que cualquier notificación relativa al mensaje que acabas de crear termine en el spam.</p>";
+<p><b><mark>¡Muy importante!</mark></b> Incluye la dirección <b>support@weexpire.org</b> en tu lista de contacto seguros para evitar que cualquier notificación relativa al mensaje que acabas de crear termine en el spam.<br>Además, verifica que el código QR y su código de acceso estén impresos completos y sean claramente legibles. Si es necesario, ajusta la escala y los márgenes de impresión. Por último, escanea el código QR con la cámara de tu teléfono solo para asegurarte de que abre la página de acceso de tu nota de emergencia, sin continuar.</p>";
 $translation["done_page_donate_message"] = "<p class='text-center'><small>Apoya a WeExpire con una <a href='/donate' target='_blank'>donación</a>.</small></p>";
 
 // Access page

--- a/htdocs/PHP/internal_libraries/languages/page_content_fr.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_fr.php
@@ -98,7 +98,7 @@ $translation["review_page_information_6"] = "Cette note ne pourra pas être modi
 $translation["done_page_title"] = "Tout est prêt";
 $translation["done_page_content"] = "
 <p>Votre note d'urgence a été créée. Vous pouvez le télécharger en cliquant sur le bouton ci-dessous, puis l'imprimer et la remettre à votre personne de confiance.</p>
-<p><b><mark>Très important !</mark></b> Ajoutez l'adresse e-mail <b>support@weexpire.org</b> à la liste des expéditeurs sûrs de votre fournisseur de mails pour éviter que toute notification de notre part concernant la note que vous venez de créer ne se retrouve par erreur dans les spams.</p>";
+<p><b><mark>Très important !</mark></b> Ajoutez l'adresse e-mail <b>support@weexpire.org</b> à la liste des expéditeurs sûrs de votre fournisseur de mails pour éviter que toute notification de notre part concernant la note que vous venez de créer ne se retrouve par erreur dans les spams.<br>De plus, vérifie que le QR code et son code d’accès sont imprimés en entier et bien lisibles. Si nécessaire, ajuste l’échelle d’impression et les marges. Enfin, scanne le QR code avec la caméra de ton téléphone uniquement pour t’assurer qu’il ouvre la page d’accès à ta note d’urgence, sans aller plus loin.</p>";
 $translation["done_page_donate_message"] = "<p class='text-center'><small>Soutenez WeExpire avec un <a href='/donate' target='_blank'>don</a>.</small></p>";
 
 // Access page

--- a/htdocs/PHP/internal_libraries/languages/page_content_it.php
+++ b/htdocs/PHP/internal_libraries/languages/page_content_it.php
@@ -98,7 +98,7 @@ $translation["review_page_information_6"] = "Questa nota non potrà essere cambi
 $translation["done_page_title"] = "Tutto fatto";
 $translation["done_page_content"] = "
 <p>La tua nota d'emergenza è stata creata. Puoi scaricarla attraverso il pulsante sottostante e successivamente stamparla e consegnarla alla tua persona fidata.</p>
-<p><b><mark>Molto importante!</mark></b> Aggiungi l'indirizzo <b>support@weexpire.org</b> nella lista dei mittenti sicuri del tuo email provider per evitare che qualsiasi nostra notifica in riferimento alla nota che hai appena creato finisca erroneamente nello spam.</p>";
+<p><b><mark>Molto importante!</mark></b> Aggiungi l'indirizzo <b>support@weexpire.org</b> nella lista dei mittenti sicuri del tuo email provider per evitare che qualsiasi nostra notifica in riferimento alla nota che hai appena creato finisca erroneamente nello spam.<br>Inoltre, verifica che il QR code e il relativo codice di accesso siano stampati completi e ben leggibili. Se necessario, regola scala e margini di stampa. Infine, inquadra il QR code con la fotocamera solo per assicurarti che apra la pagina di accesso della tua nota di emergenza, senza proseguire oltre.</p>";
 $translation["done_page_donate_message"] = "<p class='text-center'><small>Supporta WeExpire con una <a href='/donate' target='_blank'>donazione</a>.</small></p>";
 
 // Access page

--- a/htdocs/pdf.php
+++ b/htdocs/pdf.php
@@ -100,7 +100,6 @@ and ($_SESSION["page_token"] == "done_page")) {
     'module_height' => 1 // height of a single module in points
   );
 
-  // QRCODE,H : QR-CODE Best error correction
   // Include in the QR code the encrypted URL that allows the user to access the relative emergency note
   $pdf->write2DBarcode("{$base_path}/access.php?m={$_SESSION['encrypted_note']}&v={$current_note_version}", 'QRCODE', 180, 33, 100, 100, $style, 'N');
 


### PR DESCRIPTION
Improved the final message in the emergency note creation flow to reduce printing errors (cut-off margins). Users are now prompted to verify the QR/access codes are fully visible and to scan the QR code to confirm it opens the access page.